### PR TITLE
Update milight.js

### DIFF
--- a/milight.js
+++ b/milight.js
@@ -228,18 +228,20 @@ adapter.on('stateChange', function (id, state) {
                     val = splitColor(state.val);
                     adapter.log.debug('Send to zone ' + zone + ' "' + dp + '": ' + JSON.stringify(val));
                 } else if (dp === 'brightness2' || dp === 'brightness') {       //now 2 variants of brightness can be used in v5
-                    if (val < 0)   val = 0;
-                    if (val > 100) val = 100;
+                    if (state.val < 0)   val = 0;
+                    if (state.val > 100) val = 100;
                     adapter.log.debug('Send to zone ' + zone + ' "' + dp + '": ' + state.val);
                 } else {
                     val = parseInt(state.val, 10);
                     adapter.log.debug('Send to zone ' + zone + ' "' + dp + '": ' + state.val);
                 }
-                light.sendCommands(zones[zone].on(zone), zones[zone][dp](state.val)).then(function () {
-                    adapter.setForeignState(id, state.val, true);
-                }, function (err) {
-                    adapter.log.error('Cannot control: ' + err);
-                });
+                if (state.val !== 0) { //if dim to 0% was chosen turn light off - error handling for iobroker.cloud combo with amazon alexa
+					light.sendCommands(zones[zone].on(zone), zones[zone][dp](state.val)).then(function () {
+						adapter.setForeignState(id, state.val, true);
+					}, function (err) {
+						adapter.log.error('Cannot control: ' + err);
+					});
+				}	
             } else
             if (dp === 'colorRGB'){ //wenn colorRGB doch keine Funktion ist ?!
                     dp = 'rgb255';


### PR DESCRIPTION
fixed checking for dimming value below 0% or above 100% in v5 protocol
fixed dimming to 0% (not available) and added turn off instead, when dimmed to 0%
fixed as workaround for alexa integration where iobroker.cloud sets dim after turn off (0% dimming)