### PR TITLE
require node 16 dues to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "type": "git",
     "url": "https://github.com/foxthefox/ioBroker.milight"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "node-milight-promise": "^0.3.1",
     "@iobroker/adapter-core": "^3.0.4"


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed at node 14 or earlier due to npm 6 not installing peerDependencies. So this adapter requires node 16 or newer.